### PR TITLE
Add Terms and Conditions link to footer

### DIFF
--- a/src/components/layout/footer/Footer.jsx
+++ b/src/components/layout/footer/Footer.jsx
@@ -127,6 +127,17 @@ export default function Footer() {
                   Notre processus
                 </Link>
               </li>
+              <li>
+                <Link
+                  href="https://atelierfreresdantan.fr/wp-content/uploads/2024/04/Atelier-des-Freres-dAntan-Conditions-Generales-de-Vente-17-avril-2024.pdf"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 text-whiteGray hover:text-accent transition-colors group"
+                >
+                  <span className="w-2 h-2 bg-accent rounded-full group-hover:bg-accent-light transition-colors"></span>
+                  Conditions Générales de Vente
+                </Link>
+              </li>
             </ul>
           </div>
 


### PR DESCRIPTION
- Add link to Terms and Conditions PDF in the About section
- Use direct URL to the hosted PDF file
- Set link to open in new tab for better user experience
- Maintain consistent styling with other footer links
- Ensure legal compliance by making T&C easily accessible