### PR TITLE
Show h1 title only on non-home pages

### DIFF
--- a/src/components/layout/header/Header.jsx
+++ b/src/components/layout/header/Header.jsx
@@ -4,19 +4,28 @@ import Link from 'next/link';
 import DesktopMenu from './DesktopMenu';
 import MobileMenu from './MobileMenu';
 import Image from 'next/image';
+import { usePathname } from 'next/navigation';
 import logo from '../../../../public/logo/logo-blue.svg'
 
 
 export default function Header() {
+  const pathname = usePathname();
+  const isHomePage = pathname === '/';
 
   return (
     <header className="fixed top-0 w-full bg-primary shadow-md text-white z-10">
       <div className="container mx-auto flex flex-col lg:flex-row py-4 justify-around items-center">
         <Image src={logo} alt="Logo" width={100} height={100} />
         <Link href="/">
-          <h1 className=" text-xl lmt-8 md:mt-0 mb-8 lg:mb-0">
-            Atelier des Frères d'Antan
-          </h1>
+          {isHomePage ? (
+            <span className="hidden">
+              Atelier des Frères d'Antan
+            </span>
+          ) : (
+            <h1 className="text-xl pt-4 md:mt-0 mb-4 lg:mb-0">
+              Atelier des Frères d'Antan
+            </h1>
+          )}
         </Link>
 
         {/* Menu Desktop */}

--- a/src/components/ui/pageTitle/PageTitle.jsx
+++ b/src/components/ui/pageTitle/PageTitle.jsx
@@ -1,10 +1,15 @@
-export default function PageTitle({ 
-  title, 
-  className = "", 
+"use client";
+import { usePathname } from "next/navigation";
+
+export default function PageTitle({
+  title,
+  className = "",
   titleClassName = "text-white rounded-lg",
 }) {
+  const pathname = usePathname();
+  const isHomePage = pathname === '/';
   return (
-    <div className={`text-center mt-20 md:my-8 ${className}`}>
+    <div className={`${isHomePage ? "my-4 pt-2 text-center" : "text-center mt-20 my-2 md:my-8"} ${className}`}>
       <h1 className={titleClassName}>
         {title}
       </h1>


### PR DESCRIPTION
- Add usePathname hook to detect current page
- Show h1 title on all pages except home page
- Use span element on home page to avoid duplicate h1 tags
- Maintain consistent styling across all pages
- Improve SEO by having proper heading hierarchy