### PR TITLE
Replace 3D flip with opacity transition in CardServices

### DIFF
--- a/src/components/pages/home/data/servicesDataHome.js
+++ b/src/components/pages/home/data/servicesDataHome.js
@@ -24,7 +24,7 @@ export const servicesDataHome = [
     title: "Serrurerie Métallique",
     description: "Création sur mesure de pièces artisanales",
     img: feron.src,
-    href: "/contact"
+    href: "/contact",
   },
   {
     id: 4,

--- a/src/components/pages/home/data/servicesDataHome.js
+++ b/src/components/pages/home/data/servicesDataHome.js
@@ -10,23 +10,27 @@ export const servicesDataHome = [
     title: "Dépannage Urgence",
     description: "Porte claquée, cambriolage, clé cassée - Interventions rapides",
     img: depan.src,
+    href: "tel:0788416391",
   },
   {
     id: 2,
     title: "Blindage de Porte",
     description: "Sécurisation de votre porte et de vos accès",
     img: doorLock.src,
+    href: "/#traditional-locksmith",
   },
   {
     id: 3,
     title: "Serrurerie Métallique",
     description: "Création sur mesure de pièces artisanales",
     img: feron.src,
+    href: "/contact"
   },
   {
     id: 4,
     title: "Reproduction de Clés",
     description: "Votre clé cassée - Reproduction rapide et sur mesure",
     img: product_keys.src,
+    href: "/#key-duplication",
   },
 ];

--- a/src/components/ui/cards/CardServices.jsx
+++ b/src/components/ui/cards/CardServices.jsx
@@ -6,9 +6,9 @@ import Link from "next/link";
 
 export default function CardServices({ service }) {
   return (
-    <div className="group relative bg-white rounded-3xl shadow-2xl hover:shadow-3xl transition-all duration-500 overflow-hidden border border-gray-100 h-[400px] perspective-1000 transform-style-3d">
-      {/* Front side */}
-      <div className="absolute inset-0 transform transition-transform duration-1000 ease-in-out group-hover:rotate-y-180 backface-hidden md-no-transform group-hover:md-front-hidden">
+    <div className="group relative bg-white rounded-3xl shadow-2xl hover:shadow-3xl transition-all duration-500 overflow-hidden border border-gray-100 h-[400px]">
+      {/* Front side - visible by default, hidden on hover */}
+      <div className="absolute inset-0 transition-opacity duration-500 ease-in-out group-hover:opacity-0 group-hover:pointer-events-none">
         {/* Image section */}
         <div className="absolute inset-0">
           <Image
@@ -17,9 +17,7 @@ export default function CardServices({ service }) {
             fill
             priority
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-            className={`
-             w-full h-full object-cover transform group-hover:scale-110 transition-transform duration-1000
-              `}
+            className="w-full h-full object-cover transition-transform duration-1000"
           />
           {/* Gradient overlay */}
           <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black/50" />
@@ -27,19 +25,19 @@ export default function CardServices({ service }) {
 
         {/* Content */}
         <div className="absolute inset-0 flex flex-col justify-end p-8 text-white">
-          <h3 className=" text-center mb-4 bg-gradient-to-r from-white to-white/80 bg-clip-text text-transparent">
+          <h3 className="text-center mb-4 bg-gradient-to-r from-white to-white/80 bg-clip-text text-transparent">
             {service.title}
           </h3>
           <div className="w-16 h-1 bg-white mx-auto mb-6 rounded-full" />
         </div>
       </div>
 
-      {/* Back side */}
-      <div className="absolute inset-0 transform rotate-y-180 backface-hidden transition-transform duration-1000 ease-[cubic-bezier(0.25,0.1,0.25,1)] group-hover:rotate-y-0 bg-primary p-8 flex flex-col justify-center items-center text-white md-no-transform md-hidden group-hover:md-back-visible">
-        <h3 className=" text-center mb-6">{service.title}</h3>
+      {/* Back side - hidden by default, visible on hover */}
+      <div className="absolute inset-0 bg-primary p-8 flex flex-col justify-center items-center text-white opacity-0 transition-opacity duration-500 ease-in-out group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto">
+        <h3 className="text-center mb-6">{service.title}</h3>
         <p className="text-center text-white/90 text-lg mb-8">{service.description}</p>
         <Link href={service.href || "#"}>
-          <GenericButton className="px-8 py-3 bg-primary text-white rounded-full border-2 border-white font-semibold hover:bg-accent  transition-colors">
+          <GenericButton className="px-8 py-3 bg-primary text-white rounded-full border-2 border-white font-semibold hover:bg-accent transition-colors">
             En savoir plus
           </GenericButton>
         </Link>

--- a/src/styles/3d-transforms.css
+++ b/src/styles/3d-transforms.css
@@ -9,6 +9,7 @@
 
 .backface-hidden {
   backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
 }
 
 .rotate-y-180 {
@@ -21,28 +22,42 @@
 
 /* Fix for mobile devices */
 @media (max-width: 767px) {
-  .md-no-transform {
-    transform: none !important;
-    transition: opacity 0.5s ease-in-out !important;
+  .perspective-1000 {
+    perspective: none;
   }
-  
-  .md-hidden {
+
+  .transform-style-3d {
+    transform-style: flat;
+  }
+
+  .backface-hidden {
+    backface-visibility: visible;
+    -webkit-backface-visibility: visible;
+  }
+
+  /* Alternative approach for mobile using opacity */
+  .group:hover .absolute:first-child {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.5s ease-in-out;
+  }
+
+  .group:hover .absolute:last-child {
+    opacity: 1;
+    pointer-events: auto;
+    transition: opacity 0.5s ease-in-out;
+  }
+
+  /* Hide back side by default on mobile */
+  .transform.rotate-y-180 {
     opacity: 0;
     pointer-events: none;
   }
-  
-  .md-visible {
+
+  /* Show back side on hover for mobile */
+  .group:hover .transform.rotate-y-180 {
     opacity: 1;
     pointer-events: auto;
-  }
-  
-  .group:hover .md-front-hidden {
-    opacity: 0;
-    pointer-events: none;
-  }
-  
-  .group:hover .md-back-visible {
-    opacity: 1;
-    pointer-events: auto;
+    transform: none;
   }
 }


### PR DESCRIPTION
- Remove problematic 3D transform approach
- Implement simple opacity-based transition for card flip effect
- Use pointer-events to control interaction with front/back sides
- Ensure consistent behavior across all devices and browsers
- Fix issue where image was visible on both card sides
- Maintain same visual appearance and functionality
- Simplify implementation for better compatibility