### PR TITLE
Fix service card links on homepage

### DIFF
--- a/src/components/pages/home/data/servicesDataHome.js
+++ b/src/components/pages/home/data/servicesDataHome.js
@@ -17,7 +17,7 @@ export const servicesDataHome = [
     title: "Blindage de Porte",
     description: "Sécurisation de votre porte et de vos accès",
     img: doorLock.src,
-    href: "/#traditional-locksmith",
+    href: "/la-serrurerie-traditionnelle#traditional-locksmith",
   },
   {
     id: 3,
@@ -31,6 +31,6 @@ export const servicesDataHome = [
     title: "Reproduction de Clés",
     description: "Votre clé cassée - Reproduction rapide et sur mesure",
     img: product_keys.src,
-    href: "/#key-duplication",
+    href: "/la-serrurerie-traditionnelle#key-duplication",
   },
 ];


### PR DESCRIPTION
- Update links to point to correct sections on service pages
- Fix 'Blindage de Porte' link to point to traditional-locksmith section
- Fix 'Reproduction de Clés' link to point to key-duplication section
- Ensure links include the correct page path prefix
- Improve user navigation from homepage to specific service sections