### PR TITLE
Fix spelling of Chevreuse in partners data

### DIFF
--- a/src/components/pages/home/sections/PartnersSection/partnersData.js
+++ b/src/components/pages/home/sections/PartnersSection/partnersData.js
@@ -1,7 +1,7 @@
 export const partners = [
   {
     id: 1,
-    name: "La Vallée de Cheuvreuse",
+    name: "La Vallée de Chevreuse",
     logo: "/img/sections/partners/chevreuse.svg",
   },
   {


### PR DESCRIPTION
- Correct misspelling of 'Cheuvreuse' to 'Chevreuse'
- Ensure accurate geographical reference
- Improve content quality and professionalism
- Maintain consistent spelling across the site