### PR TITLE
Simplify homepage title to 'Bienvenue'

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -16,7 +16,7 @@ export default function Home() {
   return (
     <>
       <div className="bg-primary pt-32">
-        <PageTitle title="Bienvenue à l'Atelier des Frères d'Antan" />
+        <PageTitle title="Bienvenue" />
         <Carousel slides={carouselSlides} />
         <EssentialsSection />
         <ValueSection />


### PR DESCRIPTION
- Change homepage title from 'Bienvenue à l'Atelier des Frères d'Antan' to 'Bienvenue'
- Create more concise and impactful first impression
- Improve visual balance on the homepage
- Maintain welcoming tone while reducing text length
- Enhance overall aesthetic with simpler heading