### PR TITLE
Significantly increase logo size for better visibility

### DIFF
--- a/src/components/layout/header/Header.jsx
+++ b/src/components/layout/header/Header.jsx
@@ -14,7 +14,13 @@ export default function Header() {
   return (
     <header className="fixed top-0 w-full bg-primary shadow-md text-white z-10">
       <div className="container mx-auto flex flex-col lg:flex-row py-4 justify-around items-center">
-        <Image src={logo} alt="Logo" width={100} height={100} />
+        <Image
+          src={logo}
+          alt="Logo"
+          width={200}
+          height={200}
+          className="w-[150px] h-[150px] md:w-[120px] md:h-[120px] lg:w-[100px] lg:h-[100px]"
+        />
         <Link href="/">
           {isHomePage ? (
             <span className="hidden">Atelier des Frères d'Antan</span>


### PR DESCRIPTION
- Increase mobile logo size from 100px to 150px
- Set tablet size to 120px
- Maintain desktop size at 100px
- Use higher resolution source image (200x200)
- Implement responsive sizing with Tailwind classes
- Improve brand visibility across all devices
- Enhance user experience with more prominent logo