### PR TITLE
Adjust PageTitle vertical margin to my-4

### DIFF
--- a/src/components/ui/pageTitle/PageTitle.jsx
+++ b/src/components/ui/pageTitle/PageTitle.jsx
@@ -7,7 +7,7 @@ export default function PageTitle({
 }) {
   return (
     <div
-      className={`"text-center mt-20 my-2 md:my-8" ${className}`}
+      className={`"text-center mt-20 my-4 md:my-8" ${className}`}
     >
       <h1 className={titleClassName}>{title}</h1>
     </div>


### PR DESCRIPTION
- Set consistent vertical margin of my-4 for better spacing
- Maintain larger margin (my-8) on medium screens and above
- Ensure proper spacing between title and surrounding content
- Fine-tune vertical rhythm for improved page layout
- Optimize spacing for better visual hierarchy