### PR TITLE
Improve header navigation and accessibility

### DIFF
--- a/src/components/layout/header/DesktopMenu.jsx
+++ b/src/components/layout/header/DesktopMenu.jsx
@@ -18,6 +18,14 @@ export default function DesktopMenu() {
     <>
       {/* Menu Desktop */}
       <nav className="relative hidden md:flex md:text-sm space-x-6 font-primary capitalize font-light tracking-wider xl:text-lg">
+        {/* Accueil */}
+        <Link
+          href="/"
+          className={`hover:text-accent-light ${pathname === "/" ? "text-accent-light" : ""}`}
+        >
+          Accueil
+        </Link>
+
         {/* Cordonnerie avec sous-menu */}
         <div
           className="relative"

--- a/src/components/layout/header/Header.jsx
+++ b/src/components/layout/header/Header.jsx
@@ -13,7 +13,7 @@ export default function Header() {
         <Link href="/">
           <Image src={logo} alt="Logo" width={500} height={500} className="w-[150px] h-[150px]" />
         </Link>
-        
+
         {/* Menu Desktop */}
         <DesktopMenu />
 

--- a/src/components/layout/header/Header.jsx
+++ b/src/components/layout/header/Header.jsx
@@ -10,13 +10,10 @@ export default function Header() {
   return (
     <header className="fixed top-0 w-full bg-primary shadow-md text-white z-10">
       <div className="container mx-auto flex flex-col lg:flex-row py-4 justify-around items-center">
-        <Image src={logo} alt="Logo" width={500} height={500} className="w-[150px] h-[150px]" />
         <Link href="/">
-          <h1 className="hidden md:block text-xl pt-4 md:mt-0 mb-4 lg:mb-0">
-            Atelier des Frères d'Antan
-          </h1>
+          <Image src={logo} alt="Logo" width={500} height={500} className="w-[150px] h-[150px]" />
         </Link>
-
+        
         {/* Menu Desktop */}
         <DesktopMenu />
 

--- a/src/components/layout/header/MobileMenu.jsx
+++ b/src/components/layout/header/MobileMenu.jsx
@@ -1,7 +1,7 @@
 // MobileMenu.jsx
 "use client";
 import Link from "next/link";
-import { BiHome, BiHistory, BiEnvelope } from "react-icons/bi";
+import { BiHistory, BiEnvelope, BiStore } from "react-icons/bi";
 import { GiRunningShoe, GiKeyLock } from "react-icons/gi";
 import { useState } from "react";
 import { MdClose, MdKeyboardArrowRight } from "react-icons/md";
@@ -76,7 +76,7 @@ export default function MobileMenu() {
               }`}
               onClick={() => setActiveTab("accueil")}
             >
-              <BiHome size={24} />
+              <BiStore size={24} />
               <span className="text-xs">Accueil</span>
             </div>
           </Link>


### PR DESCRIPTION
- Move link to homepage from title to logo for better UX
- Add 'Accueil' link to desktop menu for clearer navigation
- Replace home icon with store icon in mobile menu
- Remove title h1 in the header
- Enhance navigation consistency across desktop and mobile
- Follow web standards with clickable logo leading to homepage
- Make navigation more intuitive for all users