### PR TITLE
Enhance BeforeAfterCard component with SVG title

### DIFF
--- a/frontend/src/app/backoffice/site/medias/page.jsx
+++ b/frontend/src/app/backoffice/site/medias/page.jsx
@@ -1,0 +1,16 @@
+import BeforeAfterCard from "@/backoffice/ui/cards/BeforeAfterCard";
+
+const PageMedia = () => {
+  return (
+    <div>
+      <h1>Page de gestion des médias</h1>
+      
+    <BeforeAfterCard 
+      title="Atelier Des Frères d'Antan"
+      className="mt-8"
+       />
+      </div>
+  )
+}
+
+export default PageMedia;

--- a/frontend/src/backoffice/ui/cards/BeforeAfterCard.jsx
+++ b/frontend/src/backoffice/ui/cards/BeforeAfterCard.jsx
@@ -1,0 +1,78 @@
+'use client';
+import Image from "next/image";
+import bag from "../../../../public/img/bourrellerie/carousel/bag-repair.jpg";
+
+export default function BeforeAfterCard({
+  title,
+  beforeLabel = "AVANT",
+  afterLabel = "APRÈS",
+  className
+}) {
+  return (
+    <div className={`max-w-2xl mx-auto ${className}`}>
+      {/* Container card */}
+      <div className="bg-white rounded-xl border border-accent/10 relative overflow-hidden">
+        {/* Images container */}
+        <div className="relative flex flex-col md:flex-row items-center justify-between">
+          {/* Before Image */}
+          <div className="relative z-0 w-full md:w-1/2 h-[400px]">
+            <Image
+              src={bag}
+              alt="Before"
+              width={400}
+              height={400}
+              className="object-cover w-full h-full min-h-[450px]"
+            />
+            <div className="absolute top-4 left-4 bg-primary px-4 py-1 rounded-lg text-white">
+              {beforeLabel}
+            </div>
+          </div>
+
+          {/* Separator */}
+          <div className="hidden md:block w-[1px] h-[400px] bg-primary self-center" />
+
+          {/* After Image */}
+          <div className="relative z-0 w-full md:w-1/2 h-[400px]">
+            <Image
+              src={bag}
+              alt="After"
+              width={400}
+              height={400}
+              className="object-cover w-full h-full min-h-[450px]"
+            />
+            <div className="absolute top-4 right-4 bg-primary px-4 py-1 rounded-lg text-white">
+              {afterLabel}
+            </div>
+          </div>
+        </div>
+
+        {/* Titre en bas avec SVG - maintenant ABSOLU pour passer par-dessus */}
+        {title && (
+          <div className="absolute bottom-0 left-0 w-full z-20">
+            <svg width="100%" height="60" viewBox="0 0 100 10" preserveAspectRatio="none">
+              <polygon
+                points="0,5 100,0 100,10 0,10"
+                fill="var(--color-primary)"
+              />
+              <text
+                x="50%"
+                y="7"
+                dominantBaseline="middle"
+                textAnchor="middle"
+                markerHeight={20}
+                fill="white"
+                fontFamily="var(--font-josefin-sans)"
+                fontSize="0.15rem"
+                fontWeight="var(--font-weight-light)"
+                letterSpacing="1"
+                textTransform="uppercase"
+              >
+                {title}
+              </text>
+            </svg>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add SVG polygon for the title at the bottom of the card
- Use absolute positioning for the title to overlay the images
- Fix alignment of 'BEFORE' and 'AFTER' labels
- Adjust image and separator heights for consistency
- Implement theme colors using CSS variables